### PR TITLE
Fix the error handling to work properly even if the record is not a hash

### DIFF
--- a/lib/fluent/plugin/out_redshift.rb
+++ b/lib/fluent/plugin/out_redshift.rb
@@ -213,7 +213,8 @@ class RedshiftOutput < BufferedOutput
           tsv_text = hash_to_table_text(redshift_table_columns, hash, delimiter)
           gzw.write(tsv_text) if tsv_text and not tsv_text.empty?
         rescue => e
-          $log.error format_log("failed to create table text from #{@file_type}. text=(#{record[@record_log_tag]})"), :error=>e.to_s
+          text = record.is_a?(Hash) ? record[@record_log_tag] : record
+          $log.error format_log("failed to create table text from #{@file_type}. text=(#{text})"), :error=>e.to_s
           $log.error_backtrace
         end
       end


### PR DESCRIPTION
## Summary

Fixed the error handling in `#create_gz_file_from_structured_data` method not to cause a secondary exception.

## Background

I came across errors like this,

```
[warn]: temporarily failed to flush the buffer. next_retry=2016-04-18 10:15:31 +0900 error_class="TypeError" error="can't convert String into Integer" instance=69946758170560
[warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluent-plugin-redshift-0.1.0/lib/fluent/plugin/out_redshift.rb:189:in `[]'
[warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluent-plugin-redshift-0.1.0/lib/fluent/plugin/out_redshift.rb:189:in `rescue in block in create_gz_file_from_structured_data'
```

(Note that running version of fluent-plugin-redshift is 0.1.0, so line numbers above are different from the ones of current master branch)

It seems a value of `record` variable is not always a hash. Actual value of `record` above error was a Fixnum, so what happened here is something like this

```ruby
record = 123 # some integer value
record['log']  # => raises "can't convert String into Integer"
```

In such cases, `#create_gz_file_from_structured_data` fails and stops transferring logs to the Redshift server.
I'd like this plugin to discard such invalid records and keep on going. so I need this fix.

The cause of this invalid, non-hash record is a broken buffer file. It seems that sometimes garbage bytes slip into the file and break some records. I've not yet made sure why this happens, but I guess this is an issue of fluentd itself. In anyways, this is not in the scope of this pull request.

Could you examine this fix and merge it to the master?

Thank you in advance