### PR TITLE
Support AWS IAM roles.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Format:
         # s3 (for copying data to redshift)
         aws_key_id YOUR_AWS_KEY_ID
         aws_sec_key YOUR_AWS_SECRET_KEY
+        ## or Use IAM Role instead of credentials.
+        aws_iam_role arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME
+
         s3_bucket YOUR_S3_BUCKET
         s3_endpoint YOUR_S3_BUCKET_END_POINT
         path YOUR_S3_PATH
@@ -89,9 +92,11 @@ Example (watch and upload json formatted apache log):
 
 + `type` (required) : The value must be `redshift`.
 
-+ `aws_key_id` (required) : AWS access key id to access s3 bucket.
++ `aws_key_id` : AWS access key id to access s3 bucket.
 
-+ `aws_sec_key` (required) : AWS secret key id to access s3 bucket.
++ `aws_sec_key` : AWS secret key id to access s3 bucket.
+
++ `aws_iam_role` : AWS IAM Role name to access s3 bucket and copy into redshift.
 
 + `s3_bucket` (required) : s3 bucket name. S3 bucket must be same as the region of your Redshift cluster.
 

--- a/test/plugin/test_out_redshift.rb
+++ b/test/plugin/test_out_redshift.rb
@@ -20,6 +20,7 @@ class RedshiftOutputTest < Test::Unit::TestCase
   CONFIG_BASE= %[
     aws_key_id test_key_id
     aws_sec_key test_sec_key
+    aws_iam_role test_iam_role
     s3_bucket test_bucket
     path log
     redshift_host test_host
@@ -96,6 +97,7 @@ class RedshiftOutputTest < Test::Unit::TestCase
     d = create_driver(CONFIG_CSV)
     assert_equal "test_key_id", d.instance.aws_key_id
     assert_equal "test_sec_key", d.instance.aws_sec_key
+    assert_equal "test_iam_role", d.instance.aws_iam_role
     assert_equal "test_bucket", d.instance.s3_bucket
     assert_equal "log/", d.instance.path
     assert_equal "test_host", d.instance.redshift_host


### PR DESCRIPTION
Since Mar 29, 2016, it is supported that Redshift using IAM roles with COPY and UNLOAD commands.

https://aws.amazon.com/jp/about-aws/whats-new/2016/03/amazon-redshift-now-supports-using-iam-roles-with-copy-and-unload-commands/