### PR TITLE
Add test-unit gem dependency

### DIFF
--- a/fluent-plugin-redshift.gemspec
+++ b/fluent-plugin-redshift.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "aws-sdk-v1", ">= 1.6.3"
   gem.add_dependency "pg", "~> 0.17.0"
   gem.add_development_dependency "rake"
+  gem.add_development_dependency "test-unit", ">= 3.2.0"
   gem.add_development_dependency "simplecov", ">= 0.5.4"
   gem.add_development_dependency "flexmock", ">= 1.3.1"
 end


### PR DESCRIPTION
Recent Rubies does not export bundled test-unit gem for users.